### PR TITLE
fix: 이미지 한 장 업로드 시 map 함수 에러 발생하는 문제 해결

### DIFF
--- a/frontend/src/components/blocks/ShopRegisterModal/index.tsx
+++ b/frontend/src/components/blocks/ShopRegisterModal/index.tsx
@@ -145,7 +145,7 @@ export function ShopRegisterModal() {
 							name: res.data.name,
 							address: res.data.address,
 							explain: res.data.explain,
-							images: res.data.images,
+							images: [res.data.images],
 							category: res.data.category,
 							phone: res.data.phone,
 							subscribeCost: res.data.subscribeCost,


### PR DESCRIPTION
- store에 저장할 때, [data] 형태의 배열로 이미지 저장해야됨